### PR TITLE
Specify c++11 in node-gyp settings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -63,7 +63,9 @@
         }],
         ['OS=="mac"', {
           'xcode_settings': {
-            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+            'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++'
           },
           'variables': {
             "GS4JS_HOME%": "<!(echo $GS4JS_HOME)",


### PR DESCRIPTION
OS: macOS Sierra

I already have Xcode and Xcode developer tools installed.

As per the README, I installed ghostscript with brew and set the `GS4JS_HOME` environment variable.

When I `yarn install --force`, I get the following error:

```
error /Users/aaronsmith/Documents/XXXX/XXXX/node_modules/ghostscript4js: Command failed.
Exit code: 1
Command: sh
Arguments: -c node-gyp rebuild
Directory: /Users/aaronsmith/Documents/XXXX/XXXX/node_modules/ghostscript4js
Output:
gyp info it worked if it ends with ok
gyp info using node-gyp@3.4.0
gyp info using node@6.11.0 | darwin | x64
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp info spawn /usr/local/bin/python2
gyp info spawn args [ '/Users/aaronsmith/.nvm/versions/node/v6.11.0/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/aaronsmith/Documents/XXXX/XXXX/node_modules/ghostscript4js/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/aaronsmith/.nvm/versions/node/v6.11.0/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/aaronsmith/.node-gyp/6.11.0/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/Users/aaronsmith/.node-gyp/6.11.0',
gyp info spawn args   '-Dnode_gyp_dir=/Users/aaronsmith/.nvm/versions/node/v6.11.0/lib/node_modules/npm/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=node.lib',
gyp info spawn args   '-Dmodule_root_dir=/Users/aaronsmith/Documents/XXXX/XXXX/node_modules/ghostscript4js',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.' ]
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  CXX(target) Release/obj.target/ghostscript4js/src/ghostscript4js.o
In file included from ../src/ghostscript4js.cc:20:
../src/ghostscript4js.h:34:10: fatal error: 'mutex' file not found
#include <mutex>
         ^
1 error generated.
make: *** [Release/obj.target/ghostscript4js/src/ghostscript4js.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/aaronsmith/.nvm/versions/node/v6.11.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Darwin 16.6.0
gyp ERR! command "/Users/aaronsmith/.nvm/versions/node/v6.11.0/bin/node" "/Users/aaronsmith/.nvm/versions/node/v6.11.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/aaronsmith/Documents/XXXX/XXXX/node_modules/ghostscript4js
gyp ERR! node -v v6.11.0
gyp ERR! node-gyp -v v3.4.0
gyp ERR! not ok
```

It appears that the C++ 11 headers could not be found (mutex.h), so I specified them in the `binding.gyp` file.

`uWebSockets` had a related issue with `node-gyp`, and their solution was what worked for me. The comment is at the bottom (couldn't link to it directly).
https://github.com/uNetworking/uWebSockets/issues/93 